### PR TITLE
make session save/load logic replacable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ These are the defaults. Feel free to override them.
 " The directory to store all sessions and undo history
 let g:promiscuous_dir = $HOME . '/.vim/promiscuous'
 
-" The callback used to load a session
-let g:promiscuous_load = 'promiscuous#session#load()'
+" The callback used to load a session (receives branch name)
+let g:promiscuous_load = 'promiscuous#session#load'
 
 " The prefix prepended to all commit, stash, and log messages
 let g:promiscuous_prefix = '[Promiscuous]'
 
-" The callback used to save a session
-let g:promiscuous_save = 'promiscuous#session#save()'
+" The callback used to save a session (receives branch name)
+let g:promiscuous_save = 'promiscuous#session#save'
 
 " Log all executed commands with echom
 let g:promiscuous_verbose = 0
@@ -84,12 +84,19 @@ set undoreload=10000
 ## How does it work?
 
 ```vim
+call promiscuous#helpers#clear()
 call promiscuous#git#stash()
 call promiscuous#git#commit()
-call promiscuous#session#save()
+
+let l:branch_was = promiscuous#git#branch()
+call call(g:promiscuous_save, [l:branch_was], {})
+
 call promiscuous#session#clean()
 call promiscuous#git#checkout(l:branch)
-call promiscuous#session#load()
+
+let l:branch = promiscuous#git#branch()
+call call(g:promiscuous_load, [l:branch], {})
+
 call promiscuous#git#commit_pop()
 call promiscuous#git#stash_pop()
 call promiscuous#tmux#refresh()

--- a/README.md
+++ b/README.md
@@ -61,8 +61,14 @@ These are the defaults. Feel free to override them.
 " The directory to store all sessions and undo history
 let g:promiscuous_dir = $HOME . '/.vim/promiscuous'
 
+" The callback used to load a session
+let g:promiscuous_load = 'promiscuous#session#load()'
+
 " The prefix prepended to all commit, stash, and log messages
 let g:promiscuous_prefix = '[Promiscuous]'
+
+" The callback used to save a session
+let g:promiscuous_save = 'promiscuous#session#save()'
 
 " Log all executed commands with echom
 let g:promiscuous_verbose = 0

--- a/autoload/promiscuous/session.vim
+++ b/autoload/promiscuous/session.vim
@@ -7,7 +7,7 @@ function! promiscuous#session#file()
   return g:promiscuous_dir . '/' . l:session_name . '.vim'
 endfunction
 
-function! promiscuous#session#load()
+function! promiscuous#session#load(branch)
   let l:session_file = promiscuous#session#file()
 
   if filereadable(l:session_file)
@@ -25,7 +25,7 @@ function! promiscuous#session#name()
   return promiscuous#helpers#dasherize(l:stripped)
 endfunction
 
-function! promiscuous#session#save()
+function! promiscuous#session#save(branch)
   let l:session_file = promiscuous#session#file()
   call promiscuous#helpers#mkdir(g:promiscuous_dir)
   call promiscuous#undo#save()

--- a/plugin/promiscuous.vim
+++ b/plugin/promiscuous.vim
@@ -40,16 +40,21 @@ function! Promiscuous(...)
     call promiscuous#helpers#clear()
     call promiscuous#git#stash()
     call promiscuous#git#commit()
-    call call(g:promiscuous_save, [], {})
+
+    let l:branch_was = promiscuous#git#branch()
+    call call(g:promiscuous_save, [l:branch_was], {})
+
     call promiscuous#session#clean()
     call promiscuous#git#checkout(l:branch)
-    call call(g:promiscuous_load, [], {})
+
+    let l:branch = promiscuous#git#branch()
+    call call(g:promiscuous_load, [l:branch], {})
+
     call promiscuous#git#commit_pop()
     call promiscuous#git#stash_pop()
     call promiscuous#tmux#refresh()
 
-    let l:branch = promiscuous#git#branch()
-    call promiscuous#helpers#log('Checkout ' . l:branch)
+    call promiscuous#helpers#log(l:branch_was . ' to ' . l:branch)
 
     redraw!
   else

--- a/plugin/promiscuous.vim
+++ b/plugin/promiscuous.vim
@@ -7,9 +7,19 @@ if !exists('g:promiscuous_dir')
   let g:promiscuous_dir = $HOME . '/.vim/promiscuous'
 endif
 
+if !exists('g:promiscuous_load')
+  " The callback used to load a session
+  let g:promiscuous_load = 'promiscuous#session#load'
+endif
+
 if !exists('g:promiscuous_prefix')
   " The prefix prepended to all commit, stash, and log messages
   let g:promiscuous_prefix = '[Promiscuous]'
+endif
+
+if !exists('g:promiscuous_save')
+  " The callback used to save a session
+  let g:promiscuous_save = 'promiscuous#session#save'
 endif
 
 if !exists('g:promiscuous_verbose')
@@ -30,10 +40,10 @@ function! Promiscuous(...)
     call promiscuous#helpers#clear()
     call promiscuous#git#stash()
     call promiscuous#git#commit()
-    call promiscuous#session#save()
+    call call(g:promiscuous_save, [], {})
     call promiscuous#session#clean()
     call promiscuous#git#checkout(l:branch)
-    call promiscuous#session#load()
+    call call(g:promiscuous_load, [], {})
     call promiscuous#git#commit_pop()
     call promiscuous#git#stash_pop()
     call promiscuous#tmux#refresh()


### PR DESCRIPTION
I really like the idea of the plugin! I worked years ago with [Mylyn](http://www.eclipse.org/mylyn/) and liked it a lot. Also the huge addoption of git flow with its 'one branch per feature' idea took this task based workflow to a mainstream level without the deep opinionated approach of Mylyn.

In my opinion you should focus on the context switch logic, instead of _how_ this should be done. There are a lot of session managers for vim which have their own unique focus/features, I think. [CtrlSpace](https://github.com/szw/vim-ctrlspace) is the one I use for example. It is `mksession` on steroids plus a ton of other features. I would love to have a way to use the save/load commands of CtrlSpace to save/load the sessions on context switch.

I already saw this in the README:

``` vim
call promiscuous#git#stash()
call promiscuous#git#commit()
call promiscuous#session#save()
call promiscuous#session#clean()
call promiscuous#git#checkout(l:branch)
call promiscuous#session#load()
call promiscuous#git#commit_pop()
call promiscuous#git#stash_pop()
call promiscuous#tmux#refresh()
```

but I don't know VimL good enough to say if it is already possible to mix different plugins to modify the context switch workflow.

I would love to hear your thoughts/opinion about this :)
