### PR TITLE
handles gracefully pressing ESC in fzf

### DIFF
--- a/plugin/promiscuous.vim
+++ b/plugin/promiscuous.vim
@@ -32,7 +32,11 @@ command! -nargs=? Promiscuous :call Promiscuous(<f-args>)
 function! Promiscuous(...)
   if a:0 > 0
     if type(a:1) == type([])
-      let l:branch = a:1[-1]
+      if len(a:1) == 0  " Handles pressing ESC in fzf
+        return 1
+      else
+        let l:branch = a:1[-1]
+      end
     else
       let l:branch = a:1
     endif


### PR DESCRIPTION
Before this commit, one would get the following error:

```
    Error detected while processing function Promiscuous[29]..promiscuous#autocomplete#branches[1]..fzf#run[78]..<SNR>69_callback:
    line   33:
    Vim(let):E684: list index out of range: -1
    Error detected while processing function Promiscuous:
    line   29:
    E171: Missing :endif
```

Now Promiscuous just aborts gracefully.