### PR TITLE
Skip pre-commit hook

### DIFF
--- a/autoload/promiscuous/git.vim
+++ b/autoload/promiscuous/git.vim
@@ -12,7 +12,7 @@ function! promiscuous#git#checkout(unsanitized_branch)
 endfunction
 
 function! promiscuous#git#commit()
-  let l:commit = 'git commit -am ' . shellescape(g:promiscuous_prefix)
+  let l:commit = 'git commit -anm ' . shellescape(g:promiscuous_prefix)
   call promiscuous#helpers#exec('!git add . && ' . l:commit)
 endfunction
 


### PR DESCRIPTION
Commit function should avoid any pre-commit hook configured in the .git repo.

Some projects use this hook to run some specs/linters/whatever which could prevent vim-promiscuous from work properly.