### PR TITLE
Skip gpg-sign

### DIFF
--- a/autoload/promiscuous/git.vim
+++ b/autoload/promiscuous/git.vim
@@ -12,7 +12,7 @@ function! promiscuous#git#checkout(unsanitized_branch)
 endfunction
 
 function! promiscuous#git#commit()
-  let l:commit = 'git commit -anm ' . shellescape(g:promiscuous_prefix)
+  let l:commit = 'git commit --no-gpg-sign -anm ' . shellescape(g:promiscuous_prefix)
   call promiscuous#helpers#exec('!git add . && ' . l:commit)
 endfunction
 


### PR DESCRIPTION
Disable the global/repository config of signing a commit with gpg.

This could break the (neo)vim on Terminal when the developer is asked for the password.